### PR TITLE
Feature/#32

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -27,6 +27,7 @@ dependencies {
 
     // spring
     implementation 'org.springframework.boot:spring-boot-starter-web'
+    implementation 'org.springframework.boot:spring-boot-starter-aop'
     implementation 'org.springframework.boot:spring-boot-starter-webflux'
 //    implementation 'org.springframework.boot:spring-boot-starter-security'
 

--- a/src/main/java/com/playdata/client/chatgpt/config/GptCompletion.java
+++ b/src/main/java/com/playdata/client/chatgpt/config/GptCompletion.java
@@ -14,8 +14,7 @@ public class GptCompletion {
 
     private static final int MAX_TOKENS = 1000;
     private static final String MODEL = "text-davinci-003";
-    private static final String REQUEST_SCRIPT = "너는 편집자야\n" +
-            "\n" +
+    private static final String REQUEST_SCRIPT =
             "너가 해야되는 일\n" +
             " \n" +
             "1. 내가 마지막에 요청하는 문장을 핵심만 요약한다.\n" +
@@ -33,7 +32,7 @@ public class GptCompletion {
             "\n" +
             "3. 동사는 절대 포함하지 않는다.\n" +
             "\n" +
-            "4. 응답에는 절대 다른 말은 절대 포함하지 않고 리스트로 만든 단어만 포함한다.\n" +
+            "응답에는 절대 다른 말은 절대 포함하지 않고 리스트로 만든 단어만 포함한다. 아래 문장에 대해서 수행해\n" +
             "\n" +
-            "요청하는 문장 : \n";
+            "\n";
 }

--- a/src/main/java/com/playdata/client/chatgpt/service/ChatGptServiceImpl.java
+++ b/src/main/java/com/playdata/client/chatgpt/service/ChatGptServiceImpl.java
@@ -8,6 +8,8 @@ import com.playdata.client.chatgpt.response.GptCompletionResponse;
 import com.theokanning.openai.completion.CompletionResult;
 import com.theokanning.openai.service.OpenAiService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.retry.annotation.Backoff;
+import org.springframework.retry.annotation.Retryable;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
@@ -19,12 +21,13 @@ public class ChatGptServiceImpl implements ChatGptService {
     private final ObjectMapper objectMapper;
 
     @Override
+    @Retryable(maxAttempts = 3, backoff = @Backoff(delay = 1000L))
     public List<String> parseContent(String content) {
         String completion = completion(content).trim();
         return extractWordsFromResponse(completion);
     }
 
-    public String completion(String prompt) {
+    private String completion(String prompt) {
         CompletionResult result = openAiService.createCompletion(GptCompletion.fromPrompt(prompt));
         GptCompletionResponse response = GptCompletionResponse.of(result);
 

--- a/src/main/java/com/playdata/client/chatgpt/service/ChatGptServiceImpl.java
+++ b/src/main/java/com/playdata/client/chatgpt/service/ChatGptServiceImpl.java
@@ -8,8 +8,6 @@ import com.playdata.client.chatgpt.response.GptCompletionResponse;
 import com.theokanning.openai.completion.CompletionResult;
 import com.theokanning.openai.service.OpenAiService;
 import lombok.RequiredArgsConstructor;
-import org.springframework.retry.annotation.Backoff;
-import org.springframework.retry.annotation.Retryable;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
@@ -21,7 +19,6 @@ public class ChatGptServiceImpl implements ChatGptService {
     private final ObjectMapper objectMapper;
 
     @Override
-    @Retryable(maxAttempts = 3, backoff = @Backoff(delay = 1000L))
     public List<String> parseContent(String content) {
         String completion = completion(content).trim();
         return extractWordsFromResponse(completion);

--- a/src/main/java/com/playdata/config/AsyncConfig.java
+++ b/src/main/java/com/playdata/config/AsyncConfig.java
@@ -1,0 +1,9 @@
+package com.playdata.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.EnableAsync;
+
+@Configuration
+@EnableAsync
+public class AsyncConfig {
+}

--- a/src/main/java/com/playdata/config/RetryConfig.java
+++ b/src/main/java/com/playdata/config/RetryConfig.java
@@ -1,0 +1,9 @@
+package com.playdata.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.retry.annotation.EnableRetry;
+
+@Configuration
+@EnableRetry
+public class RetryConfig {
+}

--- a/src/main/java/com/playdata/kafka/config/TopicConfig.java
+++ b/src/main/java/com/playdata/kafka/config/TopicConfig.java
@@ -9,22 +9,44 @@ import org.springframework.kafka.config.TopicBuilder;
 public class TopicConfig {
 
     public static final String STORY = "story";
+    public static final String STORY_INDEX_FAIL = "story_index_fail";
     public static final String QUESTION = "question";
+    public static final String QUESTION_INDEX_FAIL = "question_index_fail";
 
-//    @Bean
-//    public NewTopic topicSuccessStory(){
-//        return TopicBuilder
-//                .name(STORY)
-//                .partitions(1)
-//                .replicas(1)
-//                .build();
-//    }
-//    @Bean
-//    public NewTopic topicQuestion(){
-//        return TopicBuilder
-//                .name(QUESTION)
-//                .partitions(1)
-//                .replicas(1)
-//                .build();
-//    }
+    // local 개발용 토픽, 운영환경은 task service 에서 토픽 생성 X
+    @Bean
+    public NewTopic topicStory(){
+        return TopicBuilder
+                .name(STORY)
+                .partitions(1)
+                .replicas(1)
+                .build();
+    }
+
+    @Bean
+    public NewTopic topicStoryIndexFail(){
+        return TopicBuilder
+                .name(STORY_INDEX_FAIL)
+                .partitions(1)
+                .replicas(1)
+                .build();
+    }
+
+    @Bean
+    public NewTopic topicQuestion(){
+        return TopicBuilder
+                .name(QUESTION)
+                .partitions(1)
+                .replicas(1)
+                .build();
+    }
+
+    @Bean
+    public NewTopic topicQuestionIndexFail(){
+        return TopicBuilder
+                .name(QUESTION_INDEX_FAIL)
+                .partitions(1)
+                .replicas(1)
+                .build();
+    }
 }

--- a/src/main/java/com/playdata/kafka/config/TopicConfig.java
+++ b/src/main/java/com/playdata/kafka/config/TopicConfig.java
@@ -9,9 +9,9 @@ import org.springframework.kafka.config.TopicBuilder;
 public class TopicConfig {
 
     public static final String STORY = "story";
-    public static final String STORY_INDEX_FAIL = "story_index_fail";
+    public static final String STORY_INDEX_FAIL = "story-index-fail";
     public static final String QUESTION = "question";
-    public static final String QUESTION_INDEX_FAIL = "question_index_fail";
+    public static final String QUESTION_INDEX_FAIL = "question-index-fail";
 
     // local 개발용 토픽, 운영환경은 task service 에서 토픽 생성 X
     @Bean

--- a/src/main/java/com/playdata/kafka/consumer/StoryConsumer.java
+++ b/src/main/java/com/playdata/kafka/consumer/StoryConsumer.java
@@ -2,14 +2,14 @@ package com.playdata.kafka.consumer;
 
 import com.playdata.kafka.config.TopicConfig;
 import com.playdata.kafka.dto.ArticleKafkaData;
-import com.playdata.task.TaskService;
+import com.playdata.task.service.TaskService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.kafka.annotation.KafkaListener;
 import org.springframework.stereotype.Service;
 
 @Service
 @RequiredArgsConstructor
-public class SuccessStoryConsumer {
+public class StoryConsumer {
 
     private final TaskService taskService;
 

--- a/src/main/java/com/playdata/kafka/dto/QuestionFailKafkaData.java
+++ b/src/main/java/com/playdata/kafka/dto/QuestionFailKafkaData.java
@@ -1,0 +1,8 @@
+package com.playdata.kafka.dto;
+
+public record QuestionFailKafkaData(Long id) {
+
+    public static QuestionFailKafkaData fromId(Long id){
+        return new QuestionFailKafkaData(id);
+    }
+}

--- a/src/main/java/com/playdata/kafka/dto/StoryFailKafkaData.java
+++ b/src/main/java/com/playdata/kafka/dto/StoryFailKafkaData.java
@@ -1,0 +1,8 @@
+package com.playdata.kafka.dto;
+
+public record StoryFailKafkaData(Long id) {
+
+    public static StoryFailKafkaData fromId(Long id){
+        return new StoryFailKafkaData(id);
+    }
+}

--- a/src/main/java/com/playdata/kafka/producer/QuestionProducer.java
+++ b/src/main/java/com/playdata/kafka/producer/QuestionProducer.java
@@ -1,0 +1,18 @@
+package com.playdata.kafka.producer;
+
+import com.playdata.kafka.config.TopicConfig;
+import com.playdata.kafka.dto.QuestionFailKafkaData;
+import lombok.RequiredArgsConstructor;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class QuestionProducer {
+
+    private final KafkaTemplate<String, QuestionFailKafkaData> kafkaTemplate;
+
+    public void send(Long questionId){
+        kafkaTemplate.send(TopicConfig.QUESTION_INDEX_FAIL, QuestionFailKafkaData.fromId(questionId));
+    }
+}

--- a/src/main/java/com/playdata/kafka/producer/StoryProducer.java
+++ b/src/main/java/com/playdata/kafka/producer/StoryProducer.java
@@ -1,0 +1,18 @@
+package com.playdata.kafka.producer;
+
+import com.playdata.kafka.config.TopicConfig;
+import com.playdata.kafka.dto.StoryFailKafkaData;
+import lombok.RequiredArgsConstructor;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class StoryProducer {
+
+    private final KafkaTemplate<String, StoryFailKafkaData> kafkaTemplate;
+
+    public void send(Long storyId){
+        kafkaTemplate.send(TopicConfig.STORY_INDEX_FAIL, StoryFailKafkaData.fromId(storyId));
+    }
+}

--- a/src/main/java/com/playdata/task/service/TaskService.java
+++ b/src/main/java/com/playdata/task/service/TaskService.java
@@ -34,7 +34,6 @@ public class TaskService {
     @Async
     @Retryable(maxAttempts = 3, backoff = @Backoff(delay = 1000L))
     public void taskRegister(ArticleKafkaData data){
-
         List<TaskInformation> taskInformations = data.tasks().stream()
                 .map(task -> TaskInformation.createTask(
                         task.id(),

--- a/src/main/java/com/playdata/task/service/TaskService.java
+++ b/src/main/java/com/playdata/task/service/TaskService.java
@@ -1,8 +1,6 @@
-package com.playdata.task;
+package com.playdata.task.service;
 
 import com.playdata.client.chatgpt.service.ChatGptService;
-import com.playdata.client.story.response.ArticleResponse;
-import com.playdata.client.story.service.SuccessStoryClient;
 import com.playdata.domain.articleindex.entity.ArticleIndex;
 import com.playdata.domain.articleindex.repository.ArticleIndexRepository;
 import com.playdata.domain.task.entity.TaskInformation;

--- a/src/test/java/com/playdata/task/TaskServiceTest.java
+++ b/src/test/java/com/playdata/task/TaskServiceTest.java
@@ -8,6 +8,7 @@ import com.playdata.domain.task.entity.TaskInformation;
 import com.playdata.domain.task.repository.TaskInformationRepository;
 import com.playdata.kafka.dto.ArticleKafkaData;
 import com.playdata.kafka.dto.TaskKafkaData;
+import com.playdata.task.service.TaskService;
 import jakarta.persistence.EntityManager;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;


### PR DESCRIPTION
kafka timeout을 방지하기 위해서 성공담 등록에 대한 카프카 메세지 수신을 비동기로 처리하였습니다.

일시적인 실패(네트워크 오류, 응답 형식 틀림)은 다시 요청했을 때 해결되는 경우가 있어 retryable을 사용했습니다.

3번 초과로 실패 시 완전 실패로 보고 실패 토픽을 발행하도록 했습니다.