### PR TITLE
Feature/#49

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -10,49 +10,40 @@ name: Java CI with Gradle
 on:
   push:
     branches: [ "dev" ]
-
-permissions:
-  contents: read
-
 jobs:
   build:
-
     runs-on: ubuntu-latest
-
     steps:
-    - uses: actions/checkout@v3
-    - name: Set up JDK 17
-      uses: actions/setup-java@v3
-      with:
-        java-version: '17'
-        distribution: 'temurin'
-        
-    - name: Permission
-      run: chmod 744 gradlew
-      
-    - name: Build Spring
-      run: ./gradlew clean build
+      - uses: actions/checkout@v3
 
-    - name: Build Docker image
-      run: docker build -t ${{secrets.DOCKER_USERNAME}}/${{secrets.DOCKER_REPOSITORY}} .
+      - name: Set up JDK 17
+        uses: actions/setup-java@v3
+        with:
+          java-version: '17'
+          distribution: 'temurin'
 
-    - name: Docker Login
-      uses: docker/login-action@v3.0.0
-      with:
-        username: ${{secrets.DOCKER_USERNAME}}
-        password: ${{secrets.DOCKER_PASSWORD}}
-        
-    - name: Docker push
-      run: docker push ${{secrets.DOCKER_USERNAME}}/${{secrets.DOCKER_REPOSITORY}}
+      - name: Permission
+        run: chmod 744 gradlew
 
-    - name: SSH Remote Commands
-      uses: appleboy/ssh-action@v1.0.0
-      with:
-        host: ${{secrets.HOST_IP}}
-        username: ${{secrets.HOST_USERNANE}}
-        key: ${{secrets.HOST_KEY}}
-        script: |
-          # sudo docker pull ${{secrets.DOCKER_USERNAME}}/${{secrets.DOCKER_REPOSITORY}}
-          # sudo docker stop ${{secrets.DOCKER_REPOSITORY}}
-          # sudo docker rm ${{secrets.DOCKER_REPOSITORY}}
-          # sudo docker run --name ${{secrets.DOCKER_REPOSITORY}} -d -p 8080:8080 ${{secrets.DOCKER_USERNAME}}/${{secrets.DOCKER_REPOSITORY}} 
+      - name : java build
+        run: ./gradlew clean build
+
+      - name: Docker Login
+        uses: docker/login-action@v3.0.0
+        with:
+          username: ${{secrets.DOCKER_USERNAME}}
+          password: ${{secrets.DOCKER_PASSWORD}}
+
+      - name: BUILD
+        run: docker build -t ${{secrets.DOCKER_USERNAME}}/${{secrets.DOCKER_REPOSITORY}} .
+
+      - name: Docker push
+        run: docker push ${{secrets.DOCKER_USERNAME}}/${{secrets.DOCKER_REPOSITORY}}
+
+      - name: SSH Remote Commands
+        uses: appleboy/ssh-action@v1.0.0
+        with:
+          host: ${{secrets.HOST_IP}}
+          username: ${{secrets.HOST_USERNAME}}
+          key: ${{secrets.HOST_KEY}}
+          script: kubectl rollout restart deploy task-management -n myapp

--- a/src/main/java/com/playdata/client/chatgpt/exception/ChatGptExceptionType.java
+++ b/src/main/java/com/playdata/client/chatgpt/exception/ChatGptExceptionType.java
@@ -1,6 +1,7 @@
 package com.playdata.client.chatgpt.exception;
 
 public enum ChatGptExceptionType {
+    NO_RESPONSE,
     CHAT_GPT_COMPLETION_FAIL,
     COMPLETION_RESPONSE_PARSE_FAIL
 }

--- a/src/main/java/com/playdata/client/chatgpt/service/ChatGptService.java
+++ b/src/main/java/com/playdata/client/chatgpt/service/ChatGptService.java
@@ -1,8 +1,9 @@
 package com.playdata.client.chatgpt.service;
 
 import java.util.List;
+import java.util.concurrent.CompletableFuture;
 
 public interface ChatGptService {
 
-    List<String> parseContent(String content);
+    CompletableFuture<List<String>> parseContent(String content);
 }

--- a/src/main/java/com/playdata/client/chatgpt/service/ChatGptServiceImpl.java
+++ b/src/main/java/com/playdata/client/chatgpt/service/ChatGptServiceImpl.java
@@ -1,12 +1,12 @@
 package com.playdata.client.chatgpt.service;
 
-
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.playdata.client.chatgpt.config.GptCompletion;
 import com.playdata.client.chatgpt.exception.ChatGptException;
 import com.playdata.client.chatgpt.exception.ChatGptExceptionType;
 import com.playdata.client.chatgpt.response.GptCompletionResponse;
+import com.theokanning.openai.OpenAiHttpException;
 import com.theokanning.openai.completion.chat.ChatCompletionResult;
 import com.theokanning.openai.service.OpenAiService;
 import lombok.RequiredArgsConstructor;
@@ -14,7 +14,6 @@ import org.springframework.stereotype.Service;
 
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.ExecutionException;
 
 @Service
 @RequiredArgsConstructor
@@ -23,16 +22,13 @@ public class ChatGptServiceImpl implements ChatGptService {
     private final ObjectMapper objectMapper;
 
     @Override
-    public List<String> parseContent(String content) {
-        CompletableFuture<String> completion = CompletableFuture
-                .supplyAsync(() -> completion(content).trim());
-        try {
-            // TODO : non block, async 로 변경 고민
-            return extractWordsFromResponse(completion.get());
-        } catch (InterruptedException | ExecutionException e) {
-            // TODO : 예외처리 방식 변경
-            throw new RuntimeException("CompletableFuture", e);
-        }
+    public CompletableFuture<List<String>> parseContent(String content) {
+        return CompletableFuture.supplyAsync(() -> completion(content))
+                .thenApply(this::extractWords)
+                .exceptionally(e -> {
+                    //TODO : supplyAsync 로 생성된 스레드 예외전파 ? 관리 ? Retry 전략
+                    throw new ChatGptException(ChatGptExceptionType.CHAT_GPT_COMPLETION_FAIL, e);
+                });
     }
 
     public String completion(String prompt) {

--- a/src/main/java/com/playdata/kafka/consumer/StoryConsumer.java
+++ b/src/main/java/com/playdata/kafka/consumer/StoryConsumer.java
@@ -4,17 +4,20 @@ import com.playdata.kafka.config.TopicConfig;
 import com.playdata.kafka.dto.ArticleKafkaData;
 import com.playdata.task.service.TaskService;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.kafka.annotation.KafkaListener;
 import org.springframework.stereotype.Service;
 
 @Service
 @RequiredArgsConstructor
+@Slf4j
 public class StoryConsumer {
 
     private final TaskService taskService;
 
     @KafkaListener(topics = TopicConfig.STORY)
     public void listen(ArticleKafkaData data){
+        log.info("Received Story Id : {} Topic : {}", data.id(), TopicConfig.STORY);
         taskService.taskRegister(data);
     }
 }

--- a/src/main/java/com/playdata/task/service/TaskService.java
+++ b/src/main/java/com/playdata/task/service/TaskService.java
@@ -46,7 +46,7 @@ public class TaskService {
 
     @Recover
     public void recover(ChatGptException e, ArticleKafkaData data){
-        log.error("ChatGptException : {} Cause : {} Story ID : {}", e, e.getCause(), data.id());
+        log.error("fail indexing story Story Id : {}", data.id(), e);
         storyProducer.send(data.id());
     }
 

--- a/src/test/java/com/playdata/task/TaskServiceTest.java
+++ b/src/test/java/com/playdata/task/TaskServiceTest.java
@@ -20,6 +20,7 @@ import org.springframework.test.context.ActiveProfiles;
 import java.util.List;
 import java.util.Set;
 import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
 
 import static com.playdata.domain.task.entity.Period.ALWAYS;
 import static com.playdata.domain.task.entity.Period.DAILY;
@@ -41,7 +42,6 @@ class TaskServiceTest {
 
     @BeforeEach
     public void clear() {
-        // 인메모리 몽고 DB가 초기화가 되지 않아서 임시방편..
         articleIndexRepository.deleteAll();
     }
 
@@ -58,8 +58,9 @@ class TaskServiceTest {
                 "건강하게 삶을 사는 법.",
                 List.of(task1, task2));
 
+
         when(chatGptService.parseContent(anyString()))
-                .thenReturn(List.of("건강", "삶", "법"));
+                .thenReturn(CompletableFuture.completedFuture(List.of("건강", "삶", "법")));
 
         //when
         taskService.taskRegister(articleKafkaData);
@@ -97,7 +98,8 @@ class TaskServiceTest {
                 List.of(task1, task2));
 
         when(chatGptService.parseContent(anyString()))
-                .thenReturn(List.of("건강", "삶", "법"));
+                .thenReturn(CompletableFuture.completedFuture(List.of("건강", "삶", "법")));
+
 
         //when
         taskService.taskRegister(articleKafkaData);


### PR DESCRIPTION
GPT 통신 시 예외 처리

현재 GPT를 사용하기 위해서 theokanning.openai 라이브러리를 를 사용하고 있는데
통신 간에 발생할 수 있는 예외들을 OpenAiHttpException으로 전환해서 반환하게 되어있습니다.
이를 다시 서비스의 예외로 전환하도록 처리했습니다.

GPT 통신 비동기 처리

Completable.get()으로 동기적으로 처리되던 로직을 runAsync를 사용하여 비동기로 처리하도록 바꿨습니다.
로직 자체는 비동기로 실행되는 것을 확인했으나
예외 발생 시 호출 스레드로 예외가 전파되지 않아서 @Retryble이 작동하지 않는 문제가 있습니다..
혹시 이 부분을 어떻게 하는게 좋을지 전체적으로 리뷰를 받아볼 수 있을까요 ?😂